### PR TITLE
[ci] out 디렉토리 관리

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Update data and cache
         run: |
           cp -rv ssufid/.cache/ .
-          cp -rv ssufid/out/. .
+          cp -rv ssufid/out/* .
 
       - run: rm -rf ssufid
 

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -46,6 +46,7 @@ jobs:
       # 나머지 이전 데이터 폴더를 ssufid/out으로 이동시킵니다.
       - name: Set previous data directory
         run: |
+          shopt -s extglob
           mkdir -p ssufid/out/
           mv !(.*|ssufid)/ ssufid/out/
 

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -37,10 +37,17 @@ jobs:
           cargo-target-dir: ssufid/target
           manifest-path: ssufid/Cargo.toml
 
-      - name: Copy ssufid cache directory
+      - name: Set ssufid cache directory
         run: |
           mkdir -p .cache/
-          cp -r .cache/ ssufid/
+          mv .cache/ ssufid/
+
+      # .으로 시작하는 폴더(.git, .github, .cache)와 ssufid 폴더를 제외한 
+      # 나머지 이전 데이터 폴더를 ssufid/out으로 이동시킵니다.
+      - name: Set previous data directory
+        run: |
+          mkdir -p ssufid/out/
+          mv !(.*|ssufid)/ ssufid/out/
 
       - name: Run ssufid
         run: |
@@ -55,8 +62,8 @@ jobs:
 
       - name: Update data and cache
         run: |
-          cp -r ssufid/.cache/ .
-          cp -r ssufid/out/* .
+          cp -rv ssufid/.cache/ .
+          cp -rv ssufid/out/. .
 
       - run: rm -rf ssufid
 
@@ -66,7 +73,7 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email ""
           git add .
-          (git commit -m "update: $(date +'%Y-%m-%d %H:%M')" && git push) || echo "no contents to commit"
+          (git commit -m "update: $(date +'%Y-%m-%d %H:%M')" && git push) || echo "no changes to commit"
           
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
### 관련 이슈

- yourssu/ssufid#49

해당 이슈에 따르면 모든 플러그인의 크롤링이 실패하지 않는 이상, 성공한 플러그인의 결과 데이터에 대해서는 업데이트 및 배포를 해주어야 합니다.

만약 일부 플러그인만 크롤링에 성공했다면 `ssufid/out/` 경로에 성공한 플러그인의 결과만 들어가게 됩니다.
그런데 현재 `ssufid/out/` 디렉토리를 기준으로 페이지가 배포되고 있기 때문에 실패한 플러그인의 데이터는 이번 배포에서 제외될 수 있습니다.

이러한 문제를 방지하기 위해 이전 버전의 결과 데이터를 `ssufid/out/`으로 옮긴 다음 ssufid를 수행하도록 수정했습니다.
따라서 플러그인이 크롤링에 성공했다면 데이터는 정상적으로 업데이트 될 것이고, 실패했다면 업데이트 되지 않은 이전 데이터가 `ssufid/out/`에 남아있게 되어 배포에서 제외되지 않도록 했습니다.